### PR TITLE
Fix abort on missing mbtiles files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,5 +4,7 @@
 	branch = stable
 [submodule "vendor/maplibre-gl-native"]
 	path = vendor/maplibre-gl-native
-	url = https://github.com/maplibre/maplibre-gl-native
-	branch = master
+	# url = https://github.com/maplibre/maplibre-gl-native
+	# branch = master
+	url = https://github.com/brendan-ward/maplibre-gl-native
+	branch = handle_nonexistent_mbtiles

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,5 @@
 	branch = stable
 [submodule "vendor/maplibre-gl-native"]
 	path = vendor/maplibre-gl-native
-	# url = https://github.com/maplibre/maplibre-gl-native
-	# branch = master
-	url = https://github.com/brendan-ward/maplibre-gl-native
-	branch = handle_nonexistent_mbtiles
+	url = https://github.com/maplibre/maplibre-gl-native
+	branch = master

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ pip install pymgl
 To verify that it installed correctly, run the included test suite:
 
 ```bash
-python -m pip install pytest
+python -m pip install pytest Pillow numpy pixelmatch python-dotenv
 python -m pytest --pyargs pymgl -v
 ```
 
@@ -70,7 +70,7 @@ setup and run Xvfb manually, or wrap calls to python in `Xvfb-run`.
 To verify that it installed correctly, run the included test suite:
 
 ```bash
-python -m pip install pytest
+python -m pip install pytest Pillow numpy pixelmatch python-dotenv
 xvfb-run -a --server-args="-screen 0 1024x768x24 -ac +render -noreset" \
     python -m pytest --pyargs pymgl -v
 ```
@@ -379,7 +379,17 @@ git submodule update --init --recursive \
     vendor/googletest \
     vendor/mapbox-base \
     vendor/vector-tile
+```
 
+To later update `maplibre-gl-native`:
+
+```bash
+cd vendor/maplibre-gl-native
+git checkout main
+git pull origin
+
+cd ../..
+git commit -am "update maplibre-gl-native" to latest
 ```
 
 ### Architecture

--- a/pymgl/tests/test_style.py
+++ b/pymgl/tests/test_style.py
@@ -135,6 +135,16 @@ def test_local_mbtiles_vector_source_2x():
     assert image_matches(img_data, f"{test}@2x.png", 100)
 
 
+def test_invalid_local_mbtiles_raster_source():
+    test = "example-style-mbtiles-raster-source"
+    style = read_style(f"{test}.json")
+
+    style = style.replace("mbtiles://", f"mbtiles:///invalid/")
+
+    with pytest.raises(RuntimeError, match="path not found"):
+        img_data = Map(style, 256, 256).renderPNG()
+
+
 def test_image_pattern():
     test = "example-style-image-pattern"
     style = read_style(f"{test}.json")

--- a/tests/StyleTest.cpp
+++ b/tests/StyleTest.cpp
@@ -215,6 +215,26 @@ TEST(Style, LocalMBtilesVectorSourceX2) {
     EXPECT_TRUE(image_matches(img_filename, 100));
 }
 
+TEST(Style, InvalidLocalMBtilesRasterSource) {
+    const string test = "example-style-mbtiles-raster-source";
+    string style      = read_style(test + ".json");
+
+    style = regex_replace(style, regex("mbtiles://"), "mbtiles:///invalid/");
+
+    Map map = Map(style, 256, 256, 1);
+
+    EXPECT_THROW(
+        {
+            try {
+                map.renderPNG();
+            } catch (const std::exception &e) {
+                EXPECT_NE(std::string(e.what()).find("path not found"), std::string::npos);
+                throw;
+            }
+        },
+        std::exception);
+}
+
 TEST(Style, ImagePattern) {
     const string test = "example-style-image-pattern";
     string style      = read_style(test + ".json");


### PR DESCRIPTION
Crossref: https://github.com/maplibre/maplibre-gl-native/pull/292

Adds associated tests here to ensure that we now handle missing mbtiles files as errors instead of abort.