### PR TITLE
ENH: Force remote styles to load sooner

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
     -   added `getLayerJSON` to serialize a layer's properties to JSON
     -   added `listLayers` to list layers in the map's style, and `listSources`
         to list sources
+-   load remote styles during map creation instead of on first rendering pass (#13)
 
 ## 0.3.1 (1/10/2023)
 

--- a/include/log_observer.h
+++ b/include/log_observer.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <iostream>
+#include <ostream>
+
+#include <mbgl/util/event.hpp>
+#include <mbgl/util/logging.hpp>
+
+namespace mgl_wrapper {
+
+class LogObserver : public mbgl::Log::Observer {
+
+    bool onRecord(mbgl::EventSeverity severity,
+                  mbgl::Event event,
+                  int64_t code,
+                  const std::string &msg) {
+
+        if (event == mbgl::Event::ParseStyle && severity == mbgl::EventSeverity::Warning) {
+            std::cerr << "Error parsing style: " << msg << std::endl;
+        }
+
+        // otherwise only log out errors
+        else if (severity == mbgl::EventSeverity::Error) {
+            std::cerr << "Error: " << msg << std::endl;
+        }
+
+        return true;
+    }
+};
+
+} // namespace mgl_wrapper

--- a/include/map.h
+++ b/include/map.h
@@ -10,6 +10,26 @@
 
 namespace mgl_wrapper {
 
+// adapted from mbgl/test/stub_map_observer.hpp to implement only those callbacks
+// that are used below
+class MapObserver : public mbgl::MapObserver {
+public:
+    void onDidFinishLoadingStyle() final {
+        if (didFinishLoadingStyleCallback) {
+            didFinishLoadingStyleCallback();
+        }
+    }
+
+    void onDidFailLoadingMap(mbgl::MapLoadError type, const std::string &description) final {
+        if (didFailLoadingMapCallback) {
+            didFailLoadingMapCallback(type, description);
+        }
+    }
+
+    std::function<void()> didFinishLoadingStyleCallback;
+    std::function<void(mbgl::MapLoadError, const std::string &)> didFailLoadingMapCallback;
+};
+
 class Map {
 public:
     Map(const std::string &style,
@@ -68,6 +88,9 @@ public:
 private:
     std::unique_ptr<mbgl::HeadlessFrontend> frontend;
     std::unique_ptr<mbgl::Map> map;
+
+    // std::unique_ptr<LogObserver> logObserver;
+    std::unique_ptr<MapObserver> observer;
 
     // loop must be defined on the instance or we get segfaults, but we don't
     // need to stop it (stopping works fine on MacOS, but causes things to hang

--- a/pymgl/tests/fixtures/example-style-bad-glyphs.json
+++ b/pymgl/tests/fixtures/example-style-bad-glyphs.json
@@ -1,6 +1,6 @@
 {
     "version": 8,
-    "glyphs": "http://bad/url/{fontstack}/{range}.pbf",
+    "glyphs": "http://google.com/bad-endpoint/{fontstack}/{range}.pbf",
     "sources": {
         "geojson": {
             "type": "geojson",

--- a/pymgl/tests/test_map.py
+++ b/pymgl/tests/test_map.py
@@ -191,6 +191,19 @@ def test_list_layers():
     assert map.listLayers() == []
 
 
+@pytest.mark.skipif(not MAPBOX_TOKEN, reason="MAPBOX_TOKEN not available")
+def test_list_layers_remote_style():
+    map = Map(
+        "mapbox://styles/mapbox/streets-v11",
+        10,
+        10,
+        token=MAPBOX_TOKEN,
+        provider="mapbox",
+    )
+
+    assert len(map.listLayers()) == 111
+
+
 def test_list_sources():
     map = Map(read_style("example-style-geojson.json"))
     assert map.listSources() == ["geojson"]
@@ -200,3 +213,16 @@ def test_list_sources():
 
     map = Map(read_style("example-style-mbtiles-vector-source.json"))
     assert map.listSources() == ["land"]
+
+
+@pytest.mark.skipif(not MAPBOX_TOKEN, reason="MAPBOX_TOKEN not available")
+def test_list_sources_remote_style():
+    map = Map(
+        "mapbox://styles/mapbox/streets-v11",
+        10,
+        10,
+        token=MAPBOX_TOKEN,
+        provider="mapbox",
+    )
+
+    assert map.listSources() == ["composite"]

--- a/pymgl/tests/test_style.py
+++ b/pymgl/tests/test_style.py
@@ -90,10 +90,8 @@ def test_mapbox_style_missing_token():
 
 
 def test_bad_remote_style_url():
-    with pytest.raises(
-        RuntimeError, match="loading style failed: Could not connect to the server"
-    ):
-        Map("http://localhost:8111/bogus_style")
+    with pytest.raises(RuntimeError, match="loading style failed"):
+        Map("https://google.com/bogus_style")
 
 
 @pytest.mark.skipif(not has_poorconn, reason="poorconn test lib not available")

--- a/pymgl/tests/test_style.py
+++ b/pymgl/tests/test_style.py
@@ -89,6 +89,23 @@ def test_mapbox_style_missing_token():
         Map("mapbox://styles/mapbox/streets-v11", provider="mapbox")
 
 
+def test_bad_remote_style_url():
+    with pytest.raises(
+        RuntimeError, match="loading style failed: Could not connect to the server"
+    ):
+        Map("http://localhost:8111/bogus_style")
+
+
+@pytest.mark.skipif(not has_poorconn, reason="poorconn test lib not available")
+@pytest.mark.poorconn_http_server_config(port=8111, t=1, length=10)
+def test_slow_remote_style_url(poorconn_http_server, tmp_path):
+    with pytest.raises(RuntimeError, match="request timed out"):
+        Map(
+            "http://localhost:8111/bogus_style",
+        )
+        # NOTE: this emits errors from poorconn
+
+
 def test_labels():
     test = "example-style-geojson-labels"
 
@@ -184,13 +201,32 @@ def test_missing_style():
         Map("")
 
 
-def test_invalid_style():
-    with pytest.raises(ValueError, match="style is not valid"):
-        Map("foo")
+@pytest.mark.parametrize(
+    "style,error_type,match",
+    [
+        ("invalid style", ValueError, "style is not valid"),
+        ("{invalid style", RuntimeError, "Failed to parse style"),
+        ("{invalid style}", RuntimeError, "Failed to parse style"),
+        ("{[]}", RuntimeError, "Failed to parse style"),
+        # also for short style IDs
+        ("streets-v11", ValueError, "style is not valid"),
+    ],
+)
+def test_invalid_style(style, error_type, match):
+    with pytest.raises(error_type, match=match):
+        Map(style)
 
-    # also for short mapbox style IDs
-    with pytest.raises(ValueError, match="style is not valid"):
-        Map("streets-v11")
+
+# NOTE: these will emit warnings to stderr but are not capturable from python
+@pytest.mark.parametrize(
+    "style",
+    [
+        """{"version":0}""",
+        """{"sources": []}""",
+    ],
+)
+def test_style_parse_warnings(capsys, style):
+    Map(style)
 
 
 @pytest.mark.skipif(not has_poorconn, reason="poorconn test lib not available")

--- a/src/_pymgl.cpp
+++ b/src/_pymgl.cpp
@@ -7,6 +7,7 @@
 #include <nanobind/stl/vector.h>
 #include <sstream>
 
+#include "log_observer.h"
 #include "map.h"
 
 namespace nb = nanobind;
@@ -14,6 +15,10 @@ using namespace nanobind::literals;
 using namespace mgl_wrapper;
 
 NB_MODULE(_pymgl, m) {
+    // Setup logging when module is imported
+    // TODO: pass errors / warnings back to Python
+    mbgl::Log::setObserver(std::make_unique<LogObserver>());
+
     m.doc() = "MapLibre GL native static renderer";
 
     nb::class_<Map>(m, "Map")

--- a/tests/StyleTest.cpp
+++ b/tests/StyleTest.cpp
@@ -140,7 +140,7 @@ TEST(Style, MapboxStyle) {
 }
 
 TEST(Style, BadRemoteStyleURL) {
-    EXPECT_THROW(Map("http://localhost:8111/bogus_style", 10, 10), std::runtime_error);
+    EXPECT_THROW(Map("https://google.com/bogus_style", 10, 10), std::runtime_error);
 }
 
 TEST(Style, Labels) {

--- a/tests/StyleTest.cpp
+++ b/tests/StyleTest.cpp
@@ -139,6 +139,10 @@ TEST(Style, MapboxStyle) {
     EXPECT_TRUE(image_matches(img_filename, 100));
 }
 
+TEST(Style, BadRemoteStyleURL) {
+    EXPECT_THROW(Map("http://localhost:8111/bogus_style", 10, 10), std::runtime_error);
+}
+
 TEST(Style, Labels) {
     // should render text labels
     const string test  = "example-style-geojson-labels";

--- a/tests/WrapperTest.cpp
+++ b/tests/WrapperTest.cpp
@@ -278,6 +278,16 @@ TEST(Wrapper, ListLayers) {
     EXPECT_EQ(Map(read_style("example-style-empty.json"), 10, 10).listLayers().size(), 0);
 }
 
+TEST(Wrapper, ListLayersRemoteStyle) {
+    const string token = get_token(false);
+    if (token == "") {
+        GTEST_SKIP_("Missing Mapbox Token");
+    }
+
+    Map map = Map("mapbox://styles/mapbox/streets-v11", 10, 10, 1, 0, 0, 0, token, "mapbox");
+    EXPECT_EQ(map.listLayers().size(), 111);
+}
+
 TEST(Wrapper, ListSources) {
     auto sources = Map(read_style("example-style-geojson.json"), 10, 10).listSources();
     EXPECT_EQ(sources.size(), 1);
@@ -288,4 +298,16 @@ TEST(Wrapper, ListSources) {
     sources = Map(read_style("example-style-mbtiles-vector-source.json"), 10, 10).listSources();
     EXPECT_EQ(sources.size(), 1);
     EXPECT_EQ(sources[0], "land");
+}
+
+TEST(Wrapper, ListSourcesRemoteStyle) {
+    const string token = get_token(false);
+    if (token == "") {
+        GTEST_SKIP_("Missing Mapbox Token");
+    }
+
+    Map map      = Map("mapbox://styles/mapbox/streets-v11", 10, 10, 1, 0, 0, 0, token, "mapbox");
+    auto sources = map.listSources();
+    EXPECT_EQ(sources.size(), 1);
+    EXPECT_EQ(sources[0], "composite");
 }


### PR DESCRIPTION
This forces remote styles to load as as soon as the `Map` object is instantiated rather than waiting for the first render call.  This ensures that sources and layers are populated from the remote style before accessing them.

This also adds a log observer to try and detect parsing errors that are raised internally in maplibre-gl-native as warnings.